### PR TITLE
fix:data init

### DIFF
--- a/sources/data_init.c
+++ b/sources/data_init.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   data_init.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wleite <wleite@student.42sp.org.br>        +#+  +:+       +#+        */
+/*   By: itaureli <itaureli@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/10 02:17:51 by wleite            #+#    #+#             */
-/*   Updated: 2021/09/19 11:07:30 by wleite           ###   ########.fr       */
+/*   Updated: 2021/11/28 12:36:55 by itaureli         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,6 @@ void	data_init(t_game *game)
 	game->moves = 0;
 	game->collected = 0;
 	game->collectable = 0;
-	game->player_direction = 'D';
+	game->player_direction = 'd';
 	game->end_game = 0;
 }

--- a/sources_bonus/data_init_bonus.c
+++ b/sources_bonus/data_init_bonus.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   data_init_bonus.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wleite <wleite@student.42sp.org.br>        +#+  +:+       +#+        */
+/*   By: itaureli <itaureli@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/09/10 02:17:51 by wleite            #+#    #+#             */
-/*   Updated: 2021/09/19 11:02:07 by wleite           ###   ########.fr       */
+/*   Updated: 2021/11/28 12:37:04 by itaureli         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ void	data_init(t_game *game)
 	game->moves = 0;
 	game->collected = 0;
 	game->collectable = 0;
-	game->player_direction = 'D';
+	game->player_direction = 'd';
 	game->end_game = 0;
 	game->end_game_win = 0;
 	game->loops = 0;


### PR DESCRIPTION
Ajuste no data init.

Todas as comparações nas inicializações de sprites usam 'd' e no inicio é utilizado 'D', isso faz com que apenas na primeira renderização, caso a janela seja minimizada ela fique desta forma:

![image](https://user-images.githubusercontent.com/11761170/143775078-aa75255b-ca68-443d-b2eb-87ddc7523fea.png)

Pois  ao tentar chamar o `map_update_hook_p` com base no FocusIn ele compara com 'd' e o player não aparece pois foi iniciado com 'D'.

🚀 